### PR TITLE
Fix .neetoci paths filter (supersedes #71)

### DIFF
--- a/.neetoci/default.yml
+++ b/.neetoci/default.yml
@@ -2,33 +2,6 @@ version: v1.0
 
 plan: standard-2
 
-paths:
-  - app/**
-  - bin/**
-  - config/**
-  - db/**
-  - lib/**
-  - test/**
-  - .neetoci/default.yml
-  - .neetoci/scripts/run_eslint_on_modified_files.sh
-  - .neetoci/scripts/run_rubocop_and_erblint_on_modified_files.sh
-  - .neetoci/scripts/check_schema_drift.sh
-  - Gemfile*
-  - package.json
-  - yarn.lock
-  - Rakefile
-  - .env.test
-  - config.ru
-  - .*.yml
-  - .ruby-version
-  - .node-version
-  - .nvmrc
-  - .active_record_doctor.rb
-  - .prettierrc.js
-  - "*.config.*"
-  - .eslintignore
-  - .eslintrc.js
-
 commands:
   - checkout
   - neetoci-version ruby 3.3.5

--- a/.neetoci/default.yml
+++ b/.neetoci/default.yml
@@ -2,6 +2,18 @@ version: v1.0
 
 plan: standard-2
 
+paths:
+  - lib/**
+  - spec/**
+  - config/**
+  - Gemfile*
+  - rubocop-neeto.gemspec
+  - Rakefile
+  - .ruby-version
+  - .rubocop.yml
+  - .neetoci/default.yml
+  - .neetoci/scripts/**
+
 commands:
   - checkout
   - neetoci-version ruby 3.3.5


### PR DESCRIPTION
## What was wrong

#71 added a generic, copy-pasted `paths:` filter written for a Rails+JS stack (see neetozone/neeto-engineering#1970), including `app/**`, `db/**`, `test/**`, `package.json`, `yarn.lock`, node/eslint/prettier config, and three hardcoded `.neetoci/scripts/*.sh` filenames. rubocop-neeto is a pure Ruby gem (a custom RuboCop cop pack) -- it has no Rails app, no JS at all, no `test/` directory (specs live in `spec/`), and no `.neetoci/scripts/` directory.

## What changed

Reverts #71 and re-adds a `paths:` list scoped to the real gem layout: `lib/**`, `spec/**`, `config/**` (holds `config/default.yml`, the cop definitions), `Gemfile*`, the gemspec, `Rakefile`, `.ruby-version`, `.rubocop.yml`, `.neetoci/default.yml`, and a defensive `.neetoci/scripts/**` glob per the TL's ask. Dropped `bin/**` since `.rubocop.yml` excludes `bin/**/*` and it's just standard gem scaffolding (`console`/`setup`) not exercised by any CI check.

Refs neetozone/neeto-engineering#1970