### PR TITLE
Revert "Wrap README prose at 80 columns"

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,7 @@ Install the gem and add to the application's Gemfile by executing:
 
     $ bundle add rubocop-neeto
 
-If bundler is not being used to manage dependencies, install the gem by
-executing:
+If bundler is not being used to manage dependencies, install the gem by executing:
 
     $ gem install rubocop-neeto
 
@@ -27,8 +26,7 @@ Add the following line to your `.rubocop.yml` file.
 require: rubocop-neeto
 ```
 
-Alternatively, use the following array notation when specifying multiple
-extensions.
+Alternatively, use the following array notation when specifying multiple extensions.
 
 ```yaml
 require:
@@ -41,15 +39,9 @@ standard cops.
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run
-`rspec` to run the tests. You can also run `bin/console` for an interactive
-prompt that will allow you to experiment.
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `rspec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
-To install this gem onto your local machine, run `bundle exec rake install`. To
-release a new version, update the version number in `version.rb`, and then run
-`bundle exec rake release`, which will create a git tag for the version, push
-git commits and the created tag, and push the `.gem` file to
-[rubygems.org](https://rubygems.org).
+To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and the created tag, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 
 ## Disabling Cops
 
@@ -93,5 +85,4 @@ Bug reports and pull requests are welcome.
 
 ## License
 
-The gem is available as open source under the terms of the [MIT
-License](https://opensource.org/licenses/MIT).
+The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).


### PR DESCRIPTION
**Description**

- Removed: reverts the 80-column README prose wrapping.

Restores `README.md` to its content from before the wrap commit, taken from git
history (the parent of that commit) rather than from a working copy.

Reverting so the wrapping can be redone at 120 columns from the original text.
Re-wrapping the already-wrapped file is not equivalent — wrapping at 80 can
split a line so short that re-wrapping at 120 cannot rejoin it, which affects 5
of 266 READMEs. Going back to the original avoids that.

Only `README.md` is touched.

**Checklist**

- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added the necessary label (patch/minor/major - If package publish is required).
- [x] I have followed the suggested description format and styling.

**Reviewers**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
